### PR TITLE
Allow custom metadata to override the default metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anyware/streaming-client",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "description": "Streaming Client for abstracting away state updates and commands in the anyWare project",
   "main": "dist/streaming-client.js",
   "directories": {

--- a/src/streaming-client.js
+++ b/src/streaming-client.js
@@ -162,14 +162,12 @@ export default class StreamingClient extends events.EventEmitter {
 
   _appendMetadata(message, customMetadata) {
     const metadata = {};
+    metadata.from = this._username;
+    metadata.timestamp = Date.now();
+
     if (customMetadata && Object.keys(customMetadata).length !== 0) {
       Object.assign(metadata, customMetadata);
     }
-
-    // Need to append these afterwards so that customMetadata cannot
-    // override these properties.
-    metadata.from = this._username;
-    metadata.timestamp = Date.now();
 
     message.metadata = metadata;
   }

--- a/test/streaming-client-test.js
+++ b/test/streaming-client-test.js
@@ -487,22 +487,25 @@ describe('StreamingClient', () => {
     }
   });
 
-  it('should append the expected metadata and not allow custom metadata to override that', () => {
+  it('should allow expected metadata to be overridden by custom metadata', () => {
     const username = "testUser123";
     const client = new StreamingClient({username: username});
     connectClient(client);
 
-    client.sendStateUpdate({a: 1}, {from: "invalid", timestamp: ""});
-    client.sendCommand("commandName", null, {from: "invalid5", timestamp: ""});
-    client.sendCommand("commandName", {b: 2}, {from: "invalid2", timestamp: ""});
+    const customFrom = "customName";
+    const customTimestamp = 12345;
+
+    client.sendStateUpdate({a: 1}, {from: customFrom, timestamp: 12345});
+    client.sendCommand("commandName", null, {from: customFrom, timestamp: customTimestamp});
+    client.sendCommand("commandName2", {b: 2}, {from: customFrom, timestamp: customTimestamp});
 
     expect(mockClient.publish.calledThrice).to.be.true;
 
     for (const [, sentMessage] of mockClient.publish.args) {
       const parsedMessage = JSON.parse(sentMessage);
 
-      expect(parsedMessage.metadata.from).to.equal(username);
-      expect(parsedMessage.metadata.timestamp).to.not.be.empty;
+      expect(parsedMessage.metadata.from).to.equal(customFrom);
+      expect(parsedMessage.metadata.timestamp).to.equal(customTimestamp);
     }
   });
 


### PR DESCRIPTION
This change became necessary when we needed to control the `timestamp` metadata field being sent because it was just a few milliseconds off from the timestamp being recorded for each field. 

See the usage of this API change here: https://github.com/anyWareSculpture/text-emulator/commit/314bd3053210193b83aba74e47446f14162de952#diff-3344a6d59eef8632c9d14100edef0b15R44
